### PR TITLE
Update klatt.c

### DIFF
--- a/klatt.c
+++ b/klatt.c
@@ -19,7 +19,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
+
 #include <string.h>
 #include "parwave.h"
 #include "getopt.h"


### PR DESCRIPTION
No malloc.h on mac. It's in stdlib.h for us :)
